### PR TITLE
指名回数券の登録ができる機能を実装。

### DIFF
--- a/src/main/java/CAP_FIT/TicketManagement/Controller/TicketController.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Controller/TicketController.java
@@ -1,8 +1,10 @@
 package CAP_FIT.TicketManagement.Controller;
 
+import CAP_FIT.TicketManagement.Data.NominationTicket;
 import CAP_FIT.TicketManagement.Data.User;
 import CAP_FIT.TicketManagement.Domain.UserInfo;
 import CAP_FIT.TicketManagement.Service.ConverterService;
+import CAP_FIT.TicketManagement.Service.Data.NominationTicketService;
 import CAP_FIT.TicketManagement.Service.Data.TicketUserService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -21,11 +23,13 @@ public class TicketController {
 
   private final ConverterService converterService;
   private final TicketUserService ticketUserService;
+  private final NominationTicketService nominationTicketService;
 
   @Autowired
-  public TicketController(ConverterService converterService, TicketUserService ticketUserService) {
+  public TicketController(ConverterService converterService, TicketUserService ticketUserService, NominationTicketService nominationTicketService) {
     this.converterService = converterService;
     this.ticketUserService = ticketUserService;
+    this.nominationTicketService = nominationTicketService;
   }
 
   @GetMapping("/userList")
@@ -41,5 +45,11 @@ public class TicketController {
   public ResponseEntity<String> newUser(@RequestBody @Valid User user) {
     ticketUserService.newInsertUser(user);
     return ResponseEntity.ok("会員登録が完了しました");
+  }
+
+  @PostMapping("/newNominationTicket")
+  public ResponseEntity<String> newNominationTicket(@RequestBody @Valid NominationTicket nominationTicket) {
+    nominationTicketService.newInsertNominationTicket(nominationTicket);
+    return ResponseEntity.ok("指名回数券の登録が完了しました");
   }
 }

--- a/src/main/java/CAP_FIT/TicketManagement/Data/NominationTicket.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/NominationTicket.java
@@ -2,6 +2,7 @@ package CAP_FIT.TicketManagement.Data;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import java.util.Date;
@@ -14,8 +15,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class NominationTicket {
 
-  @Min(value = 1, message = "チケットidは１以上を入力してください")
-  private int  ticketNumber;
+  private int ticketNumber;
 
   @Pattern(regexp = "^0[789]0-?\\d{4}-?\\d{4}$", message = "ハイフン付きで入力してください")
   private String userId;
@@ -24,7 +24,7 @@ public class NominationTicket {
   @Max(value = 10, message = "0以上10以下の数字を入力してください")
   private Integer remaining;
 
-  @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "日付はyyyy-mm-ddの形式で入力してください")
+  @NotNull
   private LocalDate buyDay;
 
   @Pattern(regexp = "^[ァ-ヶー]+$", message = "カタカナのみ入力できます")

--- a/src/main/java/CAP_FIT/TicketManagement/Data/StretchTicket.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/StretchTicket.java
@@ -2,9 +2,9 @@ package CAP_FIT.TicketManagement.Data;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
-import java.util.Date;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,8 +14,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class StretchTicket {
 
-  @Min(value = 1, message = "チケットidは１以上を入力してください")
-  private int  ticketNumber;
+  private int ticketNumber;
 
   @Pattern(regexp = "^0[789]0-?\\d{4}-?\\d{4}$", message = "ハイフン付きで入力してください")
   private String userId;
@@ -24,7 +23,7 @@ public class StretchTicket {
   @Max(value = 10, message = "0以上10以下の数字を入力してください")
   private Integer remaining;
 
-  @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "日付はyyyy-mm-ddの形式で入力してください")
+  @NotNull
   private LocalDate buyDay;
 
   @Pattern(regexp = "^[ァ-ヶー]+$", message = "カタカナのみ入力できます")

--- a/src/main/java/CAP_FIT/TicketManagement/Judgment/TicketJudgment.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Judgment/TicketJudgment.java
@@ -1,0 +1,27 @@
+package CAP_FIT.TicketManagement.Judgment;
+
+import CAP_FIT.TicketManagement.Data.NominationTicket;
+import CAP_FIT.TicketManagement.Data.User;
+import CAP_FIT.TicketManagement.Exception.UserNotFoundException;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TicketJudgment {
+
+  public NominationTicket insertJudgmentNominationTicket(List<User> userList, NominationTicket nominationTicket) {
+    List<String> userListId = userList.stream()
+        .map(User::getId)
+        .toList();
+
+    String nominationTicketUserId = nominationTicket.getUserId();
+
+    for (String usersId : userListId) {
+      if (usersId.equals(nominationTicketUserId)) {
+        return nominationTicket;
+      }
+    } throw new UserNotFoundException("会員ID " + nominationTicketUserId + " の会員は見つかりません");
+  }
+}
+
+

--- a/src/main/java/CAP_FIT/TicketManagement/Repository/TicketRepository.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Repository/TicketRepository.java
@@ -18,4 +18,6 @@ public interface TicketRepository {
   List<User> selectUserList(String name);
 
   void insertUser(User user);
+
+  void insertNominationTicket(NominationTicket nominationTicket);
 }

--- a/src/main/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketService.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketService.java
@@ -1,25 +1,34 @@
 package CAP_FIT.TicketManagement.Service.Data;
 
 import CAP_FIT.TicketManagement.Data.NominationTicket;
+import CAP_FIT.TicketManagement.Data.User;
+import CAP_FIT.TicketManagement.Judgment.TicketJudgment;
 import CAP_FIT.TicketManagement.Repository.TicketRepository;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class NominationTicketService {
 
   private final TicketRepository ticketRepository;
+  private final TicketJudgment ticketJudgment;
 
   @Autowired
-  public NominationTicketService(TicketRepository ticketRepository) {
+  public NominationTicketService(TicketRepository ticketRepository, TicketJudgment ticketJudgment) {
     this.ticketRepository = ticketRepository;
+    this.ticketJudgment = ticketJudgment;
   }
 
   public List<NominationTicket> searchNominationTicketList() {
     return ticketRepository.nominationTicketList();
   }
 
+  @Transactional
+  public void newInsertNominationTicket(NominationTicket nominationTicket) {
+    List<User> userList = ticketRepository.userList();
+    NominationTicket resultNominationTicket = ticketJudgment.insertJudgmentNominationTicket(userList,nominationTicket);
+    ticketRepository.insertNominationTicket(resultNominationTicket);
+  }
 }
-
-

--- a/src/main/resources/mapper/TicketRepository.xml
+++ b/src/main/resources/mapper/TicketRepository.xml
@@ -23,4 +23,9 @@
    VALUES (#{id}, #{name}, #{emailAddress}, #{membershipFee}, #{admissionDay});
   </insert>
 
+  <insert id="insertNominationTicket" parameterType="CAP_FIT.TicketManagement.Data.NominationTicket" useGeneratedKeys="true" keyProperty="ticketNumber">
+    INSERT INTO nomination_ticket (user_id, remaining, buy_day, user_name)
+    VALUES (#{userId}, #{remaining}, #{buyDay}, #{userName});
+  </insert>
+
 </mapper>

--- a/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
@@ -2,6 +2,8 @@ package CAP_FIT.TicketManagement.Controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import CAP_FIT.TicketManagement.Service.Data.NominationTicketService;
 import org.springframework.http.MediaType;
 
 import CAP_FIT.TicketManagement.Data.User;
@@ -30,6 +32,9 @@ class TicketControllerTest {
 
   @MockitoBean
   private TicketUserService ticketUserService;
+
+  @MockitoBean
+  private NominationTicketService nominationTicketService;
 
   @Test
   void 会員と回数券の情報全てをコンバーターサービスから呼び出せる() throws Exception {

--- a/src/test/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketServiceTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketServiceTest.java
@@ -1,6 +1,7 @@
 package CAP_FIT.TicketManagement.Service.Data;
 
 import CAP_FIT.TicketManagement.Data.NominationTicket;
+import CAP_FIT.TicketManagement.Judgment.TicketJudgment;
 import CAP_FIT.TicketManagement.Repository.TicketRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,11 +18,14 @@ class NominationTicketServiceTest {
   @Mock
   private TicketRepository ticketRepository;
 
+  @Mock
+  private TicketJudgment ticketJudgment;
+
   private NominationTicketService sut;
 
   @BeforeEach
   void before() {
-    sut = new NominationTicketService(ticketRepository);
+    sut = new NominationTicketService(ticketRepository,ticketJudgment);
   }
 
   @Test


### PR DESCRIPTION
チケットジャッジメントクラスに指名回数券を追加する際に会員のIDと一致するユーザーIDであれば追加が可能で、一致しなければ一致しない例外を返す処理を実装。

テストクラスには今回の機能追加に伴い必要な依存クラスを設定。