### PR TITLE
指名回数券登録機能のテストコードを実装。

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,4 +47,14 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+    jvmArgs '--add-opens', 'java.base/jdk.internal.misc=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/sun.security.x509=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.lang=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.net=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.nio=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.io=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.security=ALL-UNNAMED'
+    jvmArgs '--add-opens', 'java.base/java.math=ALL-UNNAMED'
+    jvmArgs '-javaagent:' + configurations.testRuntimeClasspath.find { it.name.contains('byte-buddy-agent') }
 }

--- a/src/main/java/CAP_FIT/TicketManagement/Data/NominationTicket.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/NominationTicket.java
@@ -33,4 +33,10 @@ public class NominationTicket {
   public NominationTicket(String userId) {
     this.userId = userId;
   }
+  public NominationTicket(String userId, Integer remaining, LocalDate buyDay, String userName) {
+    this.userId = userId;
+    this.remaining = remaining;
+    this.buyDay = buyDay;
+    this.userName = userName;
+  }
 }

--- a/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
@@ -3,6 +3,7 @@ package CAP_FIT.TicketManagement.Controller;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import CAP_FIT.TicketManagement.Data.NominationTicket;
 import CAP_FIT.TicketManagement.Service.Data.NominationTicketService;
 import org.springframework.http.MediaType;
 
@@ -49,7 +50,7 @@ class TicketControllerTest {
     String name = "テスト";
 
     mockMvc.perform(get("/userList")
-            .param("name","テスト"))
+            .param("name", "テスト"))
         .andExpect(status().isOk());
 
     Mockito.verify(converterService, Mockito.times(1)).selectUserInfo(name);
@@ -58,19 +59,39 @@ class TicketControllerTest {
   @Test
   void 会員登録メソッドをチケットユーザーサービスから呼び出せる() throws Exception {
     String massage = "会員登録が完了しました";
-    User user = new User("090-1234-5678", "テスト", "test@gmail.com", 1000, LocalDate.of(2025,9,10));
+    User user = new User("090-1234-5678", "テスト", "test@gmail.com", 1000,
+        LocalDate.of(2025, 9, 10));
 
     Mockito.doNothing().when(ticketUserService).newInsertUser(user);
 
     String jsonRequest = objectMapper.writeValueAsString(user);
 
     mockMvc.perform(post("/newUser")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(jsonRequest))
+        .andExpect(status().isOk())
+        .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE))
+        .andExpect(content().string(massage));
+
+    Mockito.verify(ticketUserService, Mockito.times(1)).newInsertUser(Mockito.any(User.class));
+  }
+
+  @Test
+  void 指名回数券登録メソッドをノミネーションチケットサービスから呼び出せる() throws Exception {
+    String massage = "指名回数券の登録が完了しました";
+    NominationTicket nominationTicket = new NominationTicket("090-1234-5678", 10, LocalDate.of(2025,9,10), "テスト");
+
+    Mockito.doNothing().when(nominationTicketService).newInsertNominationTicket(nominationTicket);
+
+    String jsonRequest = objectMapper.writeValueAsString(nominationTicket);
+
+    mockMvc.perform(post("/newNominationTicket")
         .contentType(MediaType.APPLICATION_JSON)
         .content(jsonRequest))
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN_VALUE))
         .andExpect(content().string(massage));
 
-    Mockito.verify(ticketUserService,Mockito.times(1)).newInsertUser(Mockito.any(User.class));
+    Mockito.verify(nominationTicketService,Mockito.times(1)).newInsertNominationTicket(Mockito.any(NominationTicket.class));
   }
 }

--- a/src/test/java/CAP_FIT/TicketManagement/Judgment/TicketJudgmentTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Judgment/TicketJudgmentTest.java
@@ -1,0 +1,48 @@
+package CAP_FIT.TicketManagement.Judgment;
+
+import CAP_FIT.TicketManagement.Data.NominationTicket;
+import CAP_FIT.TicketManagement.Data.User;
+import CAP_FIT.TicketManagement.Exception.UserNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TicketJudgmentTest {
+
+  private TicketJudgment sut;
+  private User user;
+
+  @BeforeEach
+  void before() {
+    sut = new TicketJudgment();
+    user = new User("090-1234-5678");
+  }
+  
+  @Test
+  void 会員リストのIDにマッチする指名回数券のユーザーIDがあれば指名回数券を返す() {
+    List<User> userList = new ArrayList<>();
+    userList.add(user);
+
+    NominationTicket nominationTicket = new NominationTicket("090-1234-5678");
+
+    NominationTicket actual = sut.insertJudgmentNominationTicket(userList, nominationTicket);
+
+    Assertions.assertEquals(nominationTicket.getUserId(),actual.getUserId());
+  }
+
+  @Test
+  void 会員リストのIDにマッチする指名回数券のユーザーIDがなければ例外を返す() {
+    List<User> userList = new ArrayList<>();
+    userList.add(user);
+
+    NominationTicket nominationTicket = new NominationTicket("090-1234-5689");
+
+    UserNotFoundException actual = Assertions.assertThrows(UserNotFoundException.class, () -> {
+      sut.insertJudgmentNominationTicket(userList,nominationTicket);
+    });
+
+    Assertions.assertEquals("会員ID " + nominationTicket.getUserId() + " の会員は見つかりません", actual.getMessage());
+  }
+}

--- a/src/test/java/CAP_FIT/TicketManagement/Repository/TicketRepositoryTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Repository/TicketRepositoryTest.java
@@ -1,15 +1,11 @@
 package CAP_FIT.TicketManagement.Repository;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import CAP_FIT.TicketManagement.Data.NominationTicket;
 import CAP_FIT.TicketManagement.Data.StretchTicket;
 import CAP_FIT.TicketManagement.Data.User;
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.List;
 import org.assertj.core.api.Assertions;
-import org.h2.store.Data;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,10 +16,11 @@ class TicketRepositoryTest {
   @Autowired
   private TicketRepository sut;
 
+
   @Test
   void 会員情報の全件検索が可能() {
     List<User> actual = sut.userList();
-    Assertions.assertThat(actual.size()).isEqualTo(2);
+    Assertions.assertThat(actual.size()).isEqualTo(3);
   }
 
   @Test
@@ -54,6 +51,17 @@ class TicketRepositoryTest {
     sut.insertUser(user);
 
     List<User> actual = sut.userList();
+
+    Assertions.assertThat(actual.size()).isEqualTo(4);
+  }
+
+  @Test
+  void 指名回数券の登録が可能() {
+    NominationTicket nominationTicket = new NominationTicket("090-1234-1234", 10, LocalDate.of(2025,9,1), "テスト3");
+
+    sut.insertNominationTicket(nominationTicket);
+
+    List<NominationTicket> actual = sut.nominationTicketList();
 
     Assertions.assertThat(actual.size()).isEqualTo(3);
   }

--- a/src/test/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketServiceTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Service/Data/NominationTicketServiceTest.java
@@ -1,8 +1,10 @@
 package CAP_FIT.TicketManagement.Service.Data;
 
 import CAP_FIT.TicketManagement.Data.NominationTicket;
+import CAP_FIT.TicketManagement.Data.User;
 import CAP_FIT.TicketManagement.Judgment.TicketJudgment;
 import CAP_FIT.TicketManagement.Repository.TicketRepository;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,5 +39,22 @@ class NominationTicketServiceTest {
     sut.searchNominationTicketList();
 
     Mockito.verify(ticketRepository,Mockito.times(1)).nominationTicketList();
+  }
+
+  @Test
+  void リポジトリから全件の会員情報と回数券を追加するメソッドを呼び出しチケットジャッジメントから指名回数券を追加するメソッドを呼び出せる() {
+    List<User> userList = new ArrayList<>();
+    userList.add(new User("090-1234-5678"));
+
+    NominationTicket nominationTicket = new NominationTicket("090-1234-5678", 10, LocalDate.of(2025,9,10), "テスト");
+
+    Mockito.when(ticketRepository.userList()).thenReturn(userList);
+    Mockito.when(ticketJudgment.insertJudgmentNominationTicket(userList,nominationTicket)).thenReturn(nominationTicket);
+
+    sut.newInsertNominationTicket(nominationTicket);
+
+    Mockito.verify(ticketRepository,Mockito.times(1)).userList();
+    Mockito.verify(ticketJudgment,Mockito.times(1)).insertJudgmentNominationTicket(userList,nominationTicket);
+    Mockito.verify(ticketRepository,Mockito.times(1)).insertNominationTicket(Mockito.any(NominationTicket.class));
   }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,5 +1,6 @@
 INSERT INTO gym_user (id, name, email_address, membership_fee, admission_day) VALUES ('090-1234-5678', 'テスト', 'test@gmail.com', 10000, '2025-09-01');
 INSERT INTO gym_user (id, name, email_address, membership_fee, admission_day) VALUES ('080-1234-5678', 'テスト2', 'test2@gmail.com', 10000, '2025-09-01');
+INSERT INTO gym_user (id, name, email_address, membership_fee, admission_day) VALUES ('090-1234-1234', 'テスト3', 'test3@gmail.com', 10000, '2025-09-01');
 
 INSERT INTO nomination_ticket (user_id, remaining, buy_day, user_name) VALUES ('090-1234-5678', 10 , '2025-09-01', 'テスト');
 INSERT INTO nomination_ticket (user_id, remaining, buy_day, user_name) VALUES ('080-1234-5678', 10 , '2025-09-01', 'テスト2');


### PR DESCRIPTION
それに伴いdata.aqlファイルの内容とリポジトリテストの会員の検索、登録メソッドの値の検証結果を変更。