### PR TITLE
チケットユーザーサービスの会員登録メソッドに例外処理を実装。

### DIFF
--- a/src/main/java/CAP_FIT/TicketManagement/ExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/CAP_FIT/TicketManagement/ExceptionHandler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package CAP_FIT.TicketManagement.ExceptionHandler;
 
 import CAP_FIT.TicketManagement.Exception.UserNotFoundException;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,5 +13,10 @@ public class GlobalExceptionHandler extends RuntimeException {
   @ExceptionHandler(UserNotFoundException.class)
   public ResponseEntity<String> hangleUserNotFoundException(Exception ex) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+  }
+
+  @ExceptionHandler(DuplicateKeyException.class)
+  public ResponseEntity<String> handleDuplicateKeyException(Exception ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
   }
 }

--- a/src/main/java/CAP_FIT/TicketManagement/Service/Data/TicketUserService.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Service/Data/TicketUserService.java
@@ -4,8 +4,10 @@ package CAP_FIT.TicketManagement.Service.Data;
 import CAP_FIT.TicketManagement.Data.User;
 import CAP_FIT.TicketManagement.Exception.UserNotFoundException;
 import CAP_FIT.TicketManagement.Repository.TicketRepository;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,14 +28,20 @@ public class TicketUserService {
   public List<User> searchSelectUserList(String name) {
     List<User> nameSelectUserList = ticketRepository.selectUserList(name);
 
-    if(nameSelectUserList.isEmpty()) {
+    if (nameSelectUserList.isEmpty()) {
       throw new UserNotFoundException(name + "さんは登録されていません");
     }
-   return nameSelectUserList;
+    return nameSelectUserList;
   }
 
   @Transactional
   public void newInsertUser(User user) {
-    ticketRepository.insertUser(user);
+
+    List<User> userList = ticketRepository.userList();
+    for (User users : userList) {
+      if (users.getId().equals(user.getId())) {
+        throw new DuplicateKeyException("会員番号 " + user.getId() + " はすでに存在しています");
+      }
+    } ticketRepository.insertUser(user);
   }
 }

--- a/src/test/java/CAP_FIT/TicketManagement/Service/Data/TicketUserServiceTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Service/Data/TicketUserServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
 
 @ExtendWith(MockitoExtension.class)
 class TicketUserServiceTest {
@@ -77,5 +78,22 @@ class TicketUserServiceTest {
     sut.newInsertUser(user);
 
     Mockito.verify(ticketRepository,Mockito.times(1)).insertUser(user);
+  }
+
+  @Test
+  void 会員登録時に既存の会員IDと重複していれば例外を返す() {
+    List<User> userList = new ArrayList<>();
+    userList.add(new User("090-1234-5678"));
+
+    User user = new User("090-1234-5678");
+
+    Mockito.when(ticketRepository.userList()).thenReturn(userList);
+
+    DuplicateKeyException actual = Assertions.assertThrows(DuplicateKeyException.class, () -> {
+      sut.newInsertUser(user);
+    });
+
+    Assertions.assertEquals("会員番号 " + user.getId() + " はすでに存在しています", actual.getMessage());
+
   }
 }


### PR DESCRIPTION
新規追加を試みるユーザーのIDが既存のユーザーリストに存在する場合に例外メッセージを返す。

エクセプションハンドラークラスに(DuplicateKeyException.classを実装。

テストコードの実装。