### PR TITLE
チケットクラスのバリデーション内容を変更。

### DIFF
--- a/src/main/java/CAP_FIT/TicketManagement/Data/Tickets.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/Tickets.java
@@ -16,12 +16,12 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Tickets {
 
-  @NotNull(message = "回数券番号の入力は必須です。")
+
   @Min(value = 1, message = "1以上の数字を入力してください。")
   private Integer ticketNumber;
 
   @NotBlank(message = "ユーザーIDの入力は必須です。")
-  @Pattern(regexp = "^0[789]0-?\\d{4}-?\\d{4}$", message = "携帯番号をハイフン付きで入力してください。")
+  @Pattern(regexp = "^0[789]0-\\d{4}-\\d{4}$", message = "携帯番号をハイフン付きで入力してください。")
   private String userId;
 
   @Min(value = 0, message = "0以上30以下の数字を入力してください。")

--- a/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
@@ -257,7 +257,6 @@ class TicketControllerTest {
     return Stream.of(
 
         // 1. ticketNumber (回数券番号) のエラーパターン
-        Arguments.of("ticketNumber", null, List.of("回数券番号の入力は必須です。")),
         Arguments.of("ticketNumber", 0, List.of("1以上の数字を入力してください。")),
 
         // 2. userId (携帯番号) のエラーパターン


### PR DESCRIPTION
回数券登録時のチケット番号は自動生成のためバリデーションからNotNuLLを削除。

userIdフィールドの正規表現がハイフンなしの入力をキャッチしていなっかたので修正。

その変更に合わせバリデーションテストからチケット番号のnuLLの値が入力された場合コードを削除。