### PR TITLE
チケットユーザーサービスクラスの削除機能のコードを変更。

### DIFF
--- a/src/main/java/CAP_FIT/TicketManagement/Controller/TicketController.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Controller/TicketController.java
@@ -1,9 +1,11 @@
 package CAP_FIT.TicketManagement.Controller;
 
 import CAP_FIT.TicketManagement.Data.Tickets;
+import CAP_FIT.TicketManagement.Data.TrainingRecord;
 import CAP_FIT.TicketManagement.Data.User;
 import CAP_FIT.TicketManagement.Domain.UserInfo;
 import CAP_FIT.TicketManagement.Service.ConverterService;
+import CAP_FIT.TicketManagement.Service.Data.RecordService;
 import CAP_FIT.TicketManagement.Service.Data.TicketsService;
 import CAP_FIT.TicketManagement.Service.Data.TicketUserService;
 import jakarta.validation.Valid;
@@ -26,13 +28,15 @@ public class TicketController {
   private final ConverterService converterService;
   private final TicketUserService ticketUserService;
   private final TicketsService ticketsService;
+  private final RecordService recordService;
 
   @Autowired
-  public TicketController(ConverterService converterService, TicketUserService ticketUserService, TicketsService ticketsService) {
+  public TicketController(ConverterService converterService, TicketUserService ticketUserService, TicketsService ticketsService, RecordService recordService) {
 
     this.converterService = converterService;
     this.ticketUserService = ticketUserService;
     this.ticketsService = ticketsService;
+    this.recordService = recordService;
   }
 
   /**
@@ -103,5 +107,11 @@ public class TicketController {
   public ResponseEntity<String> deleteUserInfo(@RequestBody @Valid User user) {
    ticketUserService.deleteUserInfo(user);
    return ResponseEntity.ok("会員情報の削除が完了しました");
+  }
+
+  @PostMapping("/userRecord")
+  public ResponseEntity<String> userRecord(@RequestBody TrainingRecord trainingRecord) {
+   recordService.searchInsertRecord(trainingRecord);
+   return ResponseEntity.ok("新しいカルテ情報が作成されました");
   }
 }

--- a/src/main/java/CAP_FIT/TicketManagement/Data/TrainingRecord.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/TrainingRecord.java
@@ -1,0 +1,24 @@
+package CAP_FIT.TicketManagement.Data;
+
+import java.util.Date;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+
+public class TrainingRecord {
+
+  private int recordId;
+
+  private String userId;
+
+  private Date trainingMemory;
+
+  private String trainingMemo;
+
+  private String userName;
+
+}

--- a/src/main/java/CAP_FIT/TicketManagement/Repository/RecordRepository.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Repository/RecordRepository.java
@@ -1,0 +1,11 @@
+package CAP_FIT.TicketManagement.Repository;
+
+import CAP_FIT.TicketManagement.Data.TrainingRecord;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RecordRepository {
+
+  void insertRecord(TrainingRecord trainingRecord);
+
+}

--- a/src/main/java/CAP_FIT/TicketManagement/Repository/TicketRepository.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Repository/TicketRepository.java
@@ -48,14 +48,14 @@ public interface TicketRepository {
   /**
    * 回数券情報の更新が可能
    * @param tickets 回数券更新情報
-   * @return
+   * @return 更新した回数券の件数
    */
   int updateTickets(Tickets tickets);
 
   /**
    * ユーザーの削除が可能
    * @param user 削除したいユーザー情報
-   * @return
+   * @return 削除したユーザーの件数
    */
   int deleteUser(User user);
 

--- a/src/main/java/CAP_FIT/TicketManagement/Service/Data/RecordService.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Service/Data/RecordService.java
@@ -1,0 +1,21 @@
+package CAP_FIT.TicketManagement.Service.Data;
+
+import CAP_FIT.TicketManagement.Data.TrainingRecord;
+import CAP_FIT.TicketManagement.Repository.RecordRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecordService {
+
+  private final RecordRepository recordRepository;
+
+  @Autowired
+  public RecordService(RecordRepository recordRepository) {
+    this.recordRepository = recordRepository;
+  }
+
+  public void searchInsertRecord(TrainingRecord trainingRecord) {
+    recordRepository.insertRecord(trainingRecord);
+  }
+}

--- a/src/main/java/CAP_FIT/TicketManagement/Service/Data/TicketUserService.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Service/Data/TicketUserService.java
@@ -90,21 +90,13 @@ public class TicketUserService {
   }
 
   /**
-   * 削除したいユーザー情報に紐づく回数券情報リストの削除が可能
-   * @param userId 削除したいユーザーのID
-   */
-  private void searchDeleteTickets(String userId) {
-    ticketRepository.deleteTickets(userId);
-  }
-
-  /**
    * ユーザー情報とそのユーザーに紐づく回数券情報リストの一括削除が可能
-   * @param user
+   * @param user 削除したいユーザー
    */
   @Transactional
   public void deleteUserInfo(User user) {
     String id = user.getId();
-    searchDeleteTickets(id);
+    ticketRepository.deleteTickets(id);
 
     searchDeleteUser(user);
   }

--- a/src/main/resources/mapper/RecordRepository.xml
+++ b/src/main/resources/mapper/RecordRepository.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="CAP_FIT.TicketManagement.Repository.RecordRepository">
+
+  <insert id="insertRecord" parameterType="CAP_FIT.TicketManagement.Data.TrainingRecord" useGeneratedKeys="true" keyProperty="recordId">
+    INSERT INTO record (user_id,  training_memory, training_memo, user_name)
+    VALUES (#{userId}, #{trainingMemory}, #{trainingMemo}, #{userName});
+  </insert>
+
+</mapper>
+

--- a/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
+++ b/src/test/java/CAP_FIT/TicketManagement/Controller/TicketControllerTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import CAP_FIT.TicketManagement.Data.Tickets;
+import CAP_FIT.TicketManagement.Service.Data.RecordService;
 import CAP_FIT.TicketManagement.Service.Data.TicketsService;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
@@ -49,6 +50,9 @@ class TicketControllerTest {
 
   @MockitoBean
   private TicketsService ticketsService;
+
+  @MockitoBean
+  private RecordService recordService;
 
   private static ValidatorFactory factory;
   private static Validator validator;


### PR DESCRIPTION
searchDeleteTicketsメソッドを削除し、deleteUserInfoメソッドでチケットリポジトリからをdeleteTicketsメソッドを呼び出す設計に変更。

リポジトリクラスのjavadocの引数にコメントを追加。