### PR TITLE
チケットコントローラークラスのカルテ新規作成機能のテストコードを実装。

### DIFF
--- a/src/main/java/CAP_FIT/TicketManagement/Data/TrainingRecord.java
+++ b/src/main/java/CAP_FIT/TicketManagement/Data/TrainingRecord.java
@@ -1,6 +1,8 @@
 package CAP_FIT.TicketManagement.Data;
 
+import java.time.LocalDate;
 import java.util.Date;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,6 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 
 public class TrainingRecord {
 
@@ -15,7 +18,7 @@ public class TrainingRecord {
 
   private String userId;
 
-  private Date trainingMemory;
+  private LocalDate trainingMemory;
 
   private String trainingMemo;
 


### PR DESCRIPTION
チケットコントローラークラスの会員情報及び回数券情報を呼び出すメソッドのテストコードにjson形式でレスポンスを返せているか否かのコードを実装。

トレーニングレコードクラスのトレーニングメモリーフィールドをLocalDate型に変更。